### PR TITLE
Add tox.ini: requires tox 1.8 or later.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     requires = [
-        'Django (>=1.5)',
+        'Django (>=1.4)',
     ],
     install_requires = [
-        'Django>=1.5',
+        'Django>=1.4',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = {py27,py33,py34,pypy}-django{14,15,16,17}
+envlist = py27-django{14,15,16,17},{py33,py34,pypy}-django{15,16,17}
 
 [testenv]
 deps=
-  django14: Django>=1.4,<Django1.5
-  django15: Django>=1.5,<Django1.6
-  django16: Django>=1.6,<Django1.7
-  django17: Django>=1.7,<Django1.8
+  django14: Django>=1.4,<1.5
+  django15: Django>=1.5,<1.6
+  django16: Django>=1.6,<1.7
+  django17: Django>=1.7,<1.8
 commands=
   python runtests.py


### PR DESCRIPTION
The new tox does generated envlists, based on patterns.
