### PR TITLE
Add support for Django 1.8

### DIFF
--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -46,6 +46,9 @@ def resolve_blocks(template, context):
     if isinstance(template, six.string_types):
         template = get_template(template)
 
+    if hasattr(template, 'template'):
+        template = template.template
+
     # Add this templates blocks as the first
     local_blocks = dict(
         (block.name, block)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,17 +1,44 @@
+import django
 
 from django.template import Context
-from django.test.utils import setup_test_template_loader, restore_template_loaders
 
-class TemplateTestMixin(object):
-    TEMPLATES = {}
+if django.VERSION < (1, 8):
+    from django.test.utils import setup_test_template_loader, restore_template_loaders
 
-    @classmethod
-    def setUpClass(cls):
-        setup_test_template_loader(cls.TEMPLATES)
+    class TemplateTestMixin(object):
+        TEMPLATES = {}
 
-    @classmethod
-    def tearDownClass(cls):
-        restore_template_loaders()
+        @classmethod
+        def setUpClass(cls):
+            setup_test_template_loader(cls.TEMPLATES)
 
-    def setUp(self):
-        self.ctx = Context()
+        @classmethod
+        def tearDownClass(cls):
+            restore_template_loaders()
+
+        def setUp(self):
+            self.ctx = Context()
+else:
+    from django.test.utils import override_settings
+
+    class TemplateTestMixin(object):
+        TEMPLATES = {}
+
+        @classmethod
+        def setUpClass(cls):
+            cls.override = override_settings(TEMPLATES=[{
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'OPTIONS': {
+                    'loaders': [
+                        ('django.template.loaders.locmem.Loader', cls.TEMPLATES),
+                    ],
+                },
+            }])
+            cls.override.enable()
+
+        @classmethod
+        def tearDownClass(cls):
+            cls.override.disable()
+
+        def setUp(self):
+            self.ctx = Context()


### PR DESCRIPTION
This a a rather silly hack to make tests at least execute on Django 1.8. Most of them still fail because of the heavy template related changes in 1.8.