### PR TITLE
Add tests for {{ block.super }} in widgets.

### DIFF
--- a/tests/templates/inheritance/super
+++ b/tests/templates/inheritance/super
@@ -1,0 +1,1 @@
+{% load sniplates %}{% load_widgets w=widget_template %}{% widget "w:foo" %}

--- a/tests/templates/inheritance/super_widget_base
+++ b/tests/templates/inheritance/super_widget_base
@@ -1,0 +1,1 @@
+{% block foo %}BASE{% endblock %}

--- a/tests/templates/inheritance/super_widget_inherit
+++ b/tests/templates/inheritance/super_widget_inherit
@@ -1,0 +1,1 @@
+{% extends 'super_widget_base' %}{% block foo %}EXTENDING {{ block.super }}{% endblock %}

--- a/tests/test_inherited.py
+++ b/tests/test_inherited.py
@@ -1,0 +1,25 @@
+
+from django.template.loader import get_template
+from django.test import SimpleTestCase
+
+from .utils import TemplateTestMixin, template_path, override_settings
+
+
+@override_settings(
+    TEMPLATE_DIRS=[template_path('inheritance')],
+)
+class TestInheritanceTag(TemplateTestMixin, SimpleTestCase):
+
+    def test_block_super(self):
+        tmpl = get_template('super')
+        self.ctx.push({'widget_template': "super_widget_inherit"})
+        output = tmpl.render(self.ctx)
+        self.ctx.pop()
+        self.assertEqual(output, 'EXTENDING BASE')
+
+    def test_inherited_referenced_directly(self):
+        tmpl = get_template('super')
+        self.ctx.push({'widget_template': "super_widget_base"})
+        output = tmpl.render(self.ctx)
+        self.ctx.pop()
+        self.assertEqual(output, 'BASE')


### PR DESCRIPTION
How's this? Is this the test you want.

I notice the other inheritance templates aren't actually used in any tests, but I wasn't sure exactly what they were supposed to test.