### PR TITLE
Handle widgets used inside the content of a nested_widget.

### DIFF
--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -107,6 +107,7 @@ def using(context, alias):
 
         context.render_context.push()
         context.render_context[BLOCK_CONTEXT_KEY] = block_set
+        context.render_context[WIDGET_CONTEXT_KEY] = widgets
 
         yield context
 

--- a/tests/templates/nested_tag/keep_widgets
+++ b/tests/templates/nested_tag/keep_widgets
@@ -1,0 +1,2 @@
+{% load sniplates %}{% load_widgets w='widgets' %}
+{% nested_widget 'w:fieldset' %}{% widget 'w:CharField' %}{% endnested %}

--- a/tests/templates/nested_tag/widgets
+++ b/tests/templates/nested_tag/widgets
@@ -1,5 +1,5 @@
 {% block fieldset %}<fieldset><caption>{{ caption }}</caption>{{ content|safe }}</fieldset>{% endblock %}
-{% block CharField %}<input type="text" name="{{ html_name }}" value="{{ value|default:'' }}>{% endblock %}
+{% block CharField %}<input type="text" name="{{ html_name }}" value="{{ value|default:'' }}">{% endblock %}
 {% block ChoiceField %}<select name="{{ html_name }}" data-choices="{{ choices }}">{% for val, display in choices %}
     <option value="{{ val }}">{{ display }}</option>{% endfor %}
 </select>{% endblock %}

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -41,3 +41,9 @@ class TestNestedTag(TemplateTestMixin, SimpleTestCase):
         output = tmpl.render(self.ctx)
 
         self.assertEqual(output, '\nBEFORE <fieldset><caption>Caption</caption>content goes here</fieldset>\n')
+
+    def test_nested_content_still_has_parent_widgets(self):
+        tmpl = get_template('keep_widgets')
+        output = tmpl.render(self.ctx)
+
+        self.assertEqual(output, '\n<fieldset><caption></caption><input type="text" name="" value=""></fieldset>\n')


### PR DESCRIPTION
The new template shows the issue quite well, I believe.

When using a nested_widget, you should be able to use widgets loaded in the template you are working in.