### PR TITLE
Make django1.4 flatatt a bit more like newer versions.

### DIFF
--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -4,7 +4,10 @@ from contextlib import contextmanager
 try:
     from django.forms.utils import flatatt
 except ImportError:  # django 1.4
-    from django.forms.util import flatatt
+    from django.forms.util import flatatt as flatatt_
+    from django.utils.safestring import mark_safe
+    def flatatt(text):
+        return mark_safe(flatatt_(text))
 from django import template
 from django.template.base import token_kwargs
 from django.template.loader import get_template

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,8 @@
+from collections import OrderedDict
 from django.test import SimpleTestCase
 from django.template.loader import get_template
-from django import VERSION
 from .utils import TemplateTestMixin, template_path, override_settings
+
 
 @override_settings(
     TEMPLATE_DIRS=[template_path('filters')],
@@ -10,16 +11,11 @@ class TestFilters(TemplateTestMixin, SimpleTestCase):
 
     def test_flatattrs(self):
         tmpl = get_template('flatattrs')
-        self.ctx['a_dict'] = {
-            'a': 'aye',
-            'b': 'bee',
-            'c': 'cee',
-        }
+        self.ctx['a_dict'] = OrderedDict([
+            ('a', 'aye'),
+            ('b', 'bee'),
+            ('c', 'cee'),
+        ])
         output = tmpl.render(self.ctx)
 
-        if VERSION[:2] >= (1, 5):
-            self.assertEqual(output, ' a="aye" b="bee" c="cee" \n')
-        else:
-            self.assertTrue(' a=&quot;aye&quot; ' in output)
-            self.assertTrue(' b=&quot;bee&quot; ' in output)
-            self.assertTrue(' c=&quot;cee&quot; ' in output)
+        self.assertEqual(output, ' a="aye" b="bee" c="cee" \n')


### PR DESCRIPTION
Since newer versions explicitly call mark_safe on the result, it's safe for us to do so as well.

https://github.com/django/django/blob/master/django/forms/utils.py#L26