### PR TITLE
Fixed packaging to include the templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include *.md
+include *.py
+include LICENSE
+include tox.ini
+recursive-include docs *.bat
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+recursive-include sniplates *.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     url='http://github.com/funkybob/django-sniplates',
     keywords=['django', 'templates',],
     packages = find_packages(exclude=('tests*',)),
+    include_package_data=True,
     zip_safe=False,
     classifiers = [
         'Environment :: Web Environment',


### PR DESCRIPTION
```
> pip install django-sniplates
Successfully installed django-sniplates Django
> cd lib/python2.7/site-packages/sniplates/
> tree .
.
├── __init__.py
├── models.py
└── templatetags
    ├── __init__.py
    └── sniplates.py

1 directory, 4 files
```
So yeah, according to the `0.3.1` tag the `templates/sniplates/django.html` file should be part of the release, but it wasn't.

The following patch fixes that.
Used `check-manifest` (`pip install`) to generate the MANIFEST.in of what should definitely be in the sdist.
To check it works:
* run `setup.py build` and run `tree build` 
* run `pip install wheel`
* `setup.py bdist_wheel`
* rename the `.whl` file to `.zip` and unzip it, and then `tree` the directory extracted.