### PR TITLE
[WIP] Hacking out support for optgroup choices values.

### DIFF
--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -131,10 +131,27 @@ Fields not derived from InputField:
 >{{ value|default:'' }}</textarea>
 {% endblock %}
 
+
+Underscore prefixed to avoid potentially clashing with:
+ - {field}_{name}
+ - {widget}_{name}
+ - {field}_{widget}
+{% block _Select_Option %}
+<option value="{{ val }}" {% if val == value|default:None %}selected{% endif %}>{{ display }}</option>
+{% endblock %}
+
 {% block Select %}
 <select name="{{ html_name }}" id="{{ id }}" {{ widget.attrs|flatattrs }}>
-{% for val, display in choices %}
-    <option value="{{ val }}" {% if val == value|default:None %}selected{% endif %}>{{ display }}</option>
+{% for choice in choices %}
+    {% if choice.is_group %}
+    <optgroup label="{{ choice.value }}">
+        {% for val, display in choice.display %}
+            {% reuse '_Select_Option' val=val value=value display=display %}
+        {% endfor %}
+    </optgroup>
+    {% else %}
+        {% reuse '_Select_Option' val=choice.value value=value display=choice.display %}
+    {% endif %}
 {% endfor %}
 </select>
 {% endblock %}


### PR DESCRIPTION
Given a `choices` of ([from the docs](https://docs.djangoproject.com/en/1.8/ref/models/fields/#choices)):
```
MEDIA_CHOICES = (
    ('Audio', (
            ('vinyl', 'Vinyl'),
            ('cd', 'CD'),
        )
    ),
    ('Video', (
            ('vhs', 'VHS Tape'),
            ('dvd', 'DVD'),
        )
    ),
    ('unknown', 'Unknown'),
)
```
the existing implementation doesn't do the same as Django's `Select` widget. This is me hacking out support for handling that use case.

WIP because:
- no tests
- no docs
- only done the single widget so far (need to cover the other widgets which use `choices`)

the new wrapper object should be backwards compatible with the old choices format I think, but thoughts and feedback would be appreciated.