### PR TITLE
HTML name attributes for default widget renderers

### DIFF
--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -118,7 +118,7 @@ Fields not derived from InputField:
 
 {% block MultipleHiddenInput %}
 {% for value in value %}
-<input type="hidden" name="{{ name }}" id="{{ id }}_{{ forloop.counter0 }}" value="{{ value|default:'' }}" {{ widget.attrs|flatattrs }} {{ required|yesno:"required," }}>
+<input type="hidden" name="{{ html_name }}" id="{{ id }}_{{ forloop.counter0 }}" value="{{ value|default:'' }}" {{ widget.attrs|flatattrs }} {{ required|yesno:"required," }}>
 {% endfor %}
 {% endblock %}
 

--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -159,7 +159,7 @@ Checkbox is a special case and needs its own template.
 {% block RadioSelect %}
 <ul id="{{ id }}">
 {% for val, display in choices %}
-    <li><input type="radio" id="{{ id}}_{{ forloop.counter0 }}" value="{{ val }}" {% if val == value|default:"" %}checked{% endif %}>{{ display }}</li>
+    <li><input name="{{ html_name }}" type="radio" id="{{ id}}_{{ forloop.counter0 }}" value="{{ val }}" {% if val == value|default:"" %}checked{% endif %}>{{ display }}</li>
 {% endfor %}
 </ul>
 {% endblock %}
@@ -167,7 +167,7 @@ Checkbox is a special case and needs its own template.
 {% block CheckboxSelectMultiple %}
 <ul id="{{ id }}">
 {% for val, display in choices %}
-    <li><input type="checkbox" id="{{ id}}_{{ forloop.counter0 }}" value="{{ val }}" {% if val in value %}checked{% endif %}>{{ display }}</li>
+    <li><input name="{{ html_name }}" type="checkbox" id="{{ id}}_{{ forloop.counter0 }}" value="{{ val }}" {% if val in value %}checked{% endif %}>{{ display }}</li>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
- `CheckboxSelectMultiple` won't submit anything without a name. I'm expecting the same of `RadioSelect`. 
- `MultipleHiddenInput` looked to be the only widget using `name` rather than `html_name`