### PR TITLE
Added raw_value variable to form_field context

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -114,7 +114,8 @@ The following values are take from the ``BoundField``:
 - id_for_label
 - label
 - name
-- value
+- value (value of the field converted to string)
+- raw_value (e.g. True/False for BooleanField or datetime.datetime for DateTimeField)
 
 If the field is a FileField, an extra value `file` will be added, which
 contains the size and url attributes of the current file.  If it's an

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -319,6 +319,7 @@ def form_field(context, field, widget=None, **kwargs):
 
     # Grab the calculated value
     value = field.value()
+    field_data['raw_value'] = value
 
     # If we have choices, help out some
     if field_data['choices']:


### PR DESCRIPTION
This adds the raw_value context variable in the form_field template tag. 

Should also help #29.

Example:

```
{% block DateTimePickerInput %}
    {% reuse "input" field_type="text" value=raw_value|date:"d.m.Y H:i" %}
 {% endblock %}
```
