### PR TITLE
Add test for the shipped widgets + fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
   - "pypy3"
 env:
@@ -19,6 +20,10 @@ script:
 
 matrix:
   exclude:
+    - env: DJANGO="Django<1.8"
+      python: "3.5"
+    - env: DJANGO="Django<1.9"
+      python: "3.5"
     - env: DJANGO="Django<1.10"
       python: "3.3"
     - env: DJANGO="Django<1.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - DJANGO="Django<1.10"
 
 install:
-  - pip install $DJANGO --use-mirrors
+  - pip install $DJANGO
 
 script:
   - python runtests.py

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ setup(
     author_email='curtis@tinbrain.net',
     url='http://github.com/funkybob/django-sniplates',
     keywords=['django', 'templates', 'forms'],
-    packages = find_packages(exclude=('tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     include_package_data=True,
     zip_safe=False,
-    classifiers = [
+    classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
         'License :: OSI Approved :: BSD License',
@@ -20,12 +20,13 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    requires = [
+    requires=[
         'Django (>=1.7)',
     ],
-    install_requires = [
+    install_requires=[
         'Django>=1.7',
     ],
 )

--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -80,7 +80,7 @@ How to render errors
 <input type="{{ input_type }}"
     name="{{ html_name }}"
     id="{{ id }}"
-    value="{{ value|default:"" }}"
+    value="{{ raw_value|default:"" }}"
     class="{{ css_classes }} {{ errors|yesno:"error," }}"
     {{ widget.attrs|flatattrs }}
     {{ required|yesno:"required," }}
@@ -117,7 +117,7 @@ TODO:
 Fields not derived from InputField:
 
 {% block MultipleHiddenInput %}
-{% for value in value %}
+{% for value in raw_value %}
 <input type="hidden" name="{{ html_name }}" id="{{ id }}_{{ forloop.counter0 }}" value="{{ value|default:'' }}" {{ widget.attrs|flatattrs }} {{ required|yesno:"required," }}>
 {% endfor %}
 {% endblock %}
@@ -128,7 +128,7 @@ Fields not derived from InputField:
     {{ required|yesno:"required," }}
     {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
     {{ widget.attrs|flatattrs }}
->{{ value|default:'' }}</textarea>
+>{{ raw_value|default:'' }}</textarea>
 {% endblock %}
 
 
@@ -137,7 +137,7 @@ Underscore prefixed to avoid potentially clashing with:
  - {widget}_{name}
  - {field}_{widget}
 {% block _Select_Option %}
-<option value="{{ val }}" {% if val == value|default:None %}selected{% endif %}>{{ display }}</option>
+<option value="{{ val }}" {% if val == raw_value|default:None %}selected{% endif %}>{{ display }}</option>
 {% endblock %}
 
 {% block Select %}

--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -137,7 +137,7 @@ Underscore prefixed to avoid potentially clashing with:
  - {widget}_{name}
  - {field}_{widget}
 {% block _Select_Option %}
-<option value="{{ val }}" {% if val == raw_value|default:None %}selected{% endif %}>{{ display }}</option>
+<option value="{{ val }}" {% if val == value|default:None %}selected{% endif %}>{{ display }}</option>
 {% endblock %}
 
 {% block Select %}
@@ -146,11 +146,11 @@ Underscore prefixed to avoid potentially clashing with:
     {% if choice.is_group %}
     <optgroup label="{{ choice.value }}">
         {% for val, display in choice.display %}
-            {% reuse '_Select_Option' val=val value=value display=display %}
+            {% reuse '_Select_Option' val=val value=raw_value display=display %}
         {% endfor %}
     </optgroup>
     {% else %}
-        {% reuse '_Select_Option' val=choice.value value=value display=choice.display %}
+        {% reuse '_Select_Option' val=choice.value value=raw_value display=choice.display %}
     {% endif %}
 {% endfor %}
 </select>

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -267,6 +267,11 @@ def nested_widget(parser, token):
     return NestedWidget(widget, nodelist, kwargs, asvar)
 
 
+class ChoiceWrapper(namedtuple('ChoiceWrapper', 'value display')):
+    def is_group(self):
+        return isinstance(self.display, (list, tuple))
+
+
 class FieldExtractor(dict):
     '''
     Base class for extracting Field details.
@@ -318,7 +323,7 @@ class FieldExtractor(dict):
             return c
 
         return tuple(
-            (force_text(k), v)
+            ChoiceWrapper(value=force_text(k), display=v)
             for k, v in self.form_field.field.choices
         )
 

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -354,10 +354,36 @@ class ImageFieldExtractor(FileFieldExtractor):
             return self.value.height
 
 
+class NullBooleanFieldExtractor(FieldExtractor):
+
+    @cached_property
+    def raw_value(self):
+        """
+        When the value is None, it's actually rendered as '1', see
+        ``django.forms.widgets.NullBooleanSelect.render``
+        """
+        raw_value = super(NullBooleanFieldExtractor, self).raw_value
+        if raw_value is None:
+            return '1'
+        return raw_value
+
+    @cached_property
+    def choices(self):
+        c = self['widget'].choices
+        if not c:
+            return c
+
+        return tuple(
+            ChoiceWrapper(value=force_text(k), display=v)
+            for k, v in c
+        )
+
+
 # Map of field types to functions for extracting their data
 EXTRACTOR = {
     'FileField': FileFieldExtractor,
     'ImageField': ImageFieldExtractor,
+    'NullBooleanField': NullBooleanFieldExtractor,
 }
 
 

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -7,3 +7,29 @@ class TestForm(forms.Form):
     oneof = forms.ChoiceField(choices=tuple(enumerate('abcd')))
     many = forms.MultipleChoiceField(choices=tuple(enumerate('abcd')))
     many2 = forms.MultipleChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')))
+
+
+class DjangoWidgetsForm(forms.Form):
+    char = forms.CharField()
+    email = forms.EmailField()
+    url = forms.URLField()
+    number = forms.IntegerField()
+    password = forms.CharField(widget=forms.PasswordInput)
+    hidden = forms.CharField(widget=forms.HiddenInput)
+    multiple_hidden = forms.ChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')),
+                                        widget=forms.MultipleHiddenInput)
+    date = forms.DateField()
+    datetime = forms.DateTimeField()
+    time = forms.TimeField()
+    text = forms.CharField(widget=forms.Textarea)
+    checkbox = forms.BooleanField()
+    select = forms.ChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')))
+    null_boolean_select = forms.NullBooleanField()
+    select_multiple = forms.MultipleChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')))
+    radio_select = forms.ChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')),
+                                     widget=forms.RadioSelect)
+    checkbox_select_multiple = forms.MultipleChoiceField(
+        choices=((1, 'a'), (11, 'b'), (22, 'c')),
+        widget=forms.CheckboxSelectMultiple
+    )
+    # TODO: clearableFileInput, FileInput, Split(Hidden)DateTimeWidget

--- a/tests/templates/field_tag/widgets_django
+++ b/tests/templates/field_tag/widgets_django
@@ -1,0 +1,6 @@
+{% load sniplates %}
+{% load_widgets form="sniplates/django.html" %}
+{% for field in form %}
+{% form_field field %}
+{% endfor %}
+{{ form.null_boolean_select }}

--- a/tests/templates/field_tag/widgets_django
+++ b/tests/templates/field_tag/widgets_django
@@ -3,4 +3,3 @@
 {% for field in form %}
 {% form_field field %}
 {% endfor %}
-{{ form.null_boolean_select }}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,9 +1,9 @@
 
 from django.template import TemplateSyntaxError
 from django.template.loader import get_template
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
-from .utils import TemplateTestMixin, template_path, override_settings
+from .utils import TemplateTestMixin, template_path
 
 
 @override_settings(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from django.template.loader import get_template
-from .utils import TemplateTestMixin, template_path, override_settings
+from .utils import TemplateTestMixin, template_path
 
 
 @override_settings(

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,9 +1,9 @@
 
 from django.template.loader import get_template
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from .forms import TestForm
-from .utils import TemplateTestMixin, template_path, override_settings
+from .utils import TemplateTestMixin, template_path
 
 
 @override_settings(

--- a/tests/test_inherited.py
+++ b/tests/test_inherited.py
@@ -1,8 +1,8 @@
 from django.template import TemplateSyntaxError
 from django.template.loader import get_template
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
-from .utils import TemplateTestMixin, template_path, override_settings
+from .utils import TemplateTestMixin, template_path
 
 
 @override_settings(

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -1,10 +1,10 @@
 
 from django.template import TemplateSyntaxError
 from django.template.loader import get_template
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from .forms import TestForm
-from .utils import TemplateTestMixin, template_path, override_settings
+from .utils import TemplateTestMixin, template_path
 
 
 @override_settings(

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -1,8 +1,8 @@
 
 from django.template.loader import get_template
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
-from .utils import TemplateTestMixin, template_path, override_settings
+from .utils import TemplateTestMixin, template_path
 
 
 @override_settings(

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -3,10 +3,10 @@ Tests for all shipped sniplates/django.html widgets.
 """
 
 from django.template.loader import get_template
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from .forms import DjangoWidgetsForm
-from .utils import TemplateTestMixin, template_path, override_settings
+from .utils import TemplateTestMixin, template_path
 
 
 @override_settings(TEMPLATE_DIRS=[template_path('field_tag')])
@@ -26,21 +26,22 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
         # map field to expected widget output
         expected_output = {
-            'char': '<input type="text" name="char" id="id_char" value="" class="" required>',
-            'email': '<input type="email" name="email" id="id_email" value="" class="" required>',
-            'url': '<input type="url" name="url" id="id_url" value="" class="" required>',
-            'number': '<input type="number" name="number" id="id_number" value="" class="" required>',
-            'password': '<input type="password" name="password" id="id_password" value="" class="" required>',
-            'hidden': '<input type="hidden" name="hidden" id="id_hidden" value="" class="" required>',
+            'char': '<input type="text" name="char" id="id_char" value="" class=" " required>',
+            'email': '<input type="email" name="email" id="id_email" value="" class=" " required>',
+            'url': '<input type="url" name="url" id="id_url" value="" class=" " required>',
+            'number': '<input type="number" name="number" id="id_number" value="" class=" " required>',
+            'password': '<input type="password" name="password" id="id_password" value="" class=" " required>',
+            'hidden': '<input type="hidden" name="hidden" id="id_hidden" value="" class=" " required>',
+            # this one is hard to test, as it may NOT contain the output - it's empty by default
             'multiple_hidden': '''
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_0" value="" required>
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_1" value="" required>
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_2" value="" required>
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_3" value="" required>''',
-            'date': '<input type="date" name="date" id="id_date" value="" class="" required>',
-            'datetime': '<input type="datetime" name="datetime" id="id_datetime" value="" class="" required>',
-            'time': '<input type="time" name="time" id="id_time" value="" class="" required>',
-            'text': '<textarea name="text" id="id_text" class="" required cols="40" rows="10"></textarea> ',
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_0" value="N" required>
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_1" value="o" required>
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_2" value="n" required>
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_3" value="e" required>''',
+            'date': '<input type="date" name="date" id="id_date" value="" class=" " required>',
+            'datetime': '<input type="datetime" name="datetime" id="id_datetime" value="" class=" " required>',
+            'time': '<input type="time" name="time" id="id_time" value="" class=" " required>',
+            'text': '<textarea name="text" id="id_text" class=" " required cols="40" rows="10"></textarea> ',
             'checkbox': '''
                 <label for="id_checkbox" class="">
                     <input name="checkbox" id="id_checkbox" type="checkbox">
@@ -88,7 +89,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         self.assertInHTML(expected_output['password'], output, msg_prefix='PasswordInput rendered incorrectly: ')
         self.assertInHTML(expected_output['hidden'], output, msg_prefix='HiddenInput rendered incorrectly: ')
 
-        self.assertInHTML(
+        self.assertNotInHTML(
             expected_output['multiple_hidden'], output, msg_prefix='MultipleHiddenInput rendered incorrectly: ')
         self.assertInHTML(expected_output['date'], output, msg_prefix='DateInput rendered incorrectly: ')
         self.assertInHTML(expected_output['datetime'], output, msg_prefix='DateTimeInput rendered incorrectly: ')
@@ -98,8 +99,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
         # all kind of selects
         self.assertInHTML(expected_output['select'], output, msg_prefix='Select rendered incorrectly: ')
-        self.assertInHTML(
-            expected_output['null_boolean_select'], output, msg_prefix='NullBooleanSelect rendered incorrectly: ')
+        # self.assertInHTML(
+        #     expected_output['null_boolean_select'], output, msg_prefix='NullBooleanSelect rendered incorrectly: ')
         self.assertInHTML(
             expected_output['select_multiple'], output, msg_prefix='SelectMultiple rendered incorrectly: ')
         self.assertInHTML(expected_output['radio_select'], output, msg_prefix='RadioSelect rendered incorrectly: ')

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -1,0 +1,109 @@
+"""
+Tests for all shipped sniplates/django.html widgets.
+"""
+
+from django.template.loader import get_template
+from django.test import SimpleTestCase
+
+from .forms import DjangoWidgetsForm
+from .utils import TemplateTestMixin, template_path, override_settings
+
+
+@override_settings(TEMPLATE_DIRS=[template_path('field_tag')])
+class TestFieldTag(TemplateTestMixin, SimpleTestCase):
+
+    def setUp(self):
+        super(TestFieldTag, self).setUp()
+        self.ctx['form'] = DjangoWidgetsForm()
+
+    def test_widgets_unbound(self):
+        """
+        Tests all form fields one by one, with a fresh, unbound form without
+        initial data.
+        """
+        tmpl = get_template('widgets_django')
+        output = tmpl.render(self.ctx)
+
+        # map field to expected widget output
+        expected_output = {
+            'char': '<input type="text" name="char" id="id_char" value="" class="" required>',
+            'email': '<input type="email" name="email" id="id_email" value="" class="" required>',
+            'url': '<input type="url" name="url" id="id_url" value="" class="" required>',
+            'number': '<input type="number" name="number" id="id_number" value="" class="" required>',
+            'password': '<input type="password" name="password" id="id_password" value="" class="" required>',
+            'hidden': '<input type="hidden" name="hidden" id="id_hidden" value="" class="" required>',
+            'multiple_hidden': '''
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_0" value="" required>
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_1" value="" required>
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_2" value="" required>
+                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_3" value="" required>''',
+            'date': '<input type="date" name="date" id="id_date" value="" class="" required>',
+            'datetime': '<input type="datetime" name="datetime" id="id_datetime" value="" class="" required>',
+            'time': '<input type="time" name="time" id="id_time" value="" class="" required>',
+            'text': '<textarea name="text" id="id_text" class="" required cols="40" rows="10"></textarea> ',
+            'checkbox': '''
+                <label for="id_checkbox" class="">
+                    <input name="checkbox" id="id_checkbox" type="checkbox">
+                    Checkbox
+                </label>''',
+            'select': '''
+                <select name="select" id="id_select">
+                <option value="1">a</option>
+                <option value="11">b</option>
+                <option value="22">c</option>
+                </select>''',
+            'null_boolean_select': '''
+                <select id="id_null_boolean_select" name="null_boolean_select">
+                <option value="1" selected="selected">Unknown</option>
+                <option value="2">Yes</option>
+                <option value="3">No</option>
+                </select>''',
+            'select_multiple': '''
+                <select name="select_multiple" id="id_select_multiple" multiple>
+                    <option value="1">a</option>
+                    <option value="11">b</option>
+                    <option value="22">c</option>
+                </select>''',
+            'radio_select': '''
+                <ul id="id_radio_select">
+                    <li><input name="radio_select" type="radio" id="id_radio_select_0" value="1" >a</li>
+                    <li><input name="radio_select" type="radio" id="id_radio_select_1" value="11" >b</li>
+                    <li><input name="radio_select" type="radio" id="id_radio_select_2" value="22" >c</li>
+                </ul>''',
+            'checkbox_select_multiple': '''
+                <ul id="id_checkbox_select_multiple">
+                    <li><input name="checkbox_select_multiple" type="checkbox"
+                        id="id_checkbox_select_multiple_0" value="1">a</li>
+                    <li><input name="checkbox_select_multiple" type="checkbox"
+                        id="id_checkbox_select_multiple_1" value="11">b</li>
+                    <li><input name="checkbox_select_multiple" type="checkbox"
+                        id="id_checkbox_select_multiple_2" value="22">c</li>
+                </ul>''',
+        }
+
+        self.assertInHTML(expected_output['char'], output, msg_prefix='TextInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['email'], output, msg_prefix='EmailInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['url'], output, msg_prefix='UrlInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['number'], output, msg_prefix='NumberInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['password'], output, msg_prefix='PasswordInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['hidden'], output, msg_prefix='HiddenInput rendered incorrectly: ')
+
+        self.assertInHTML(
+            expected_output['multiple_hidden'], output, msg_prefix='MultipleHiddenInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['date'], output, msg_prefix='DateInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['datetime'], output, msg_prefix='DateTimeInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['time'], output, msg_prefix='TimeInput rendered incorrectly: ')
+        self.assertInHTML(expected_output['text'], output, msg_prefix='Textarea rendered incorrectly: ')
+        self.assertInHTML(expected_output['checkbox'], output, msg_prefix='CheckboxInput rendered incorrectly: ')
+
+        # all kind of selects
+        self.assertInHTML(expected_output['select'], output, msg_prefix='Select rendered incorrectly: ')
+        self.assertInHTML(
+            expected_output['null_boolean_select'], output, msg_prefix='NullBooleanSelect rendered incorrectly: ')
+        self.assertInHTML(
+            expected_output['select_multiple'], output, msg_prefix='SelectMultiple rendered incorrectly: ')
+        self.assertInHTML(expected_output['radio_select'], output, msg_prefix='RadioSelect rendered incorrectly: ')
+        self.assertInHTML(
+            expected_output['checkbox_select_multiple'], output,
+            msg_prefix='CheckboxSelectMultiple rendered incorrectly: '
+        )

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -99,8 +99,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
         # all kind of selects
         self.assertInHTML(expected_output['select'], output, msg_prefix='Select rendered incorrectly: ')
-        # self.assertInHTML(
-        #     expected_output['null_boolean_select'], output, msg_prefix='NullBooleanSelect rendered incorrectly: ')
+        self.assertInHTML(
+            expected_output['null_boolean_select'], output, msg_prefix='NullBooleanSelect rendered incorrectly: ')
         self.assertInHTML(
             expected_output['select_multiple'], output, msg_prefix='SelectMultiple rendered incorrectly: ')
         self.assertInHTML(expected_output['radio_select'], output, msg_prefix='RadioSelect rendered incorrectly: ')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,33 +1,6 @@
 import os
 
 from django.template import Context
-try:
-    from django.test import override_settings  # NOQA
-except ImportError:  # 1.4 Compatibility
-    # The django 1.4 override_settings does not play nicely with decorating classes.
-    from django.test.utils import override_settings as override_settings_
-    from functools import wraps
-
-    class override_settings(override_settings_):
-        def __call__(self, test_func):
-            from django.test import SimpleTestCase
-            if isinstance(test_func, type):
-                if not issubclass(test_func, SimpleTestCase):
-                    raise Exception("Only subclasses of SimpleTestCase can be decorated")
-
-                def __call__(innerself, result=None):
-                    self.enable()
-                    super(test_func, innerself).__call__(result)
-                    self.disable()
-
-                test_func.__call__ = __call__
-                return test_func
-            else:
-                @wraps(test_func)
-                def inner(*args, **kwargs):
-                    with self:
-                        return test_func(*args, **kwargs)
-            return inner
 
 
 HERE = os.path.dirname(__file__)
@@ -41,3 +14,6 @@ class TemplateTestMixin(object):
 
     def setUp(self):
         self.ctx = Context()
+
+    def assertNotInHTML(self, needle, haystack, msg_prefix=''):
+        self.assertInHTML(needle, haystack, count=0, msg_prefix=msg_prefix)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27-django{14,17,18},{py33,py34,pypy}-django{17,18}
+envlist = py{27,py}-django{17,18,19},py{33,34}-django{17,18},py{34,35}-django19
 skip_missing_interpreters = true
 
 [testenv]
 deps=
-  django14: Django>=1.4,<1.5
-  django14: django-discover-runner
   django17: Django>=1.7,<1.8
   django18: Django>=1.8,<1.9
+  django19: Django>=1.9,<1.10
 commands=
   python runtests.py


### PR DESCRIPTION
I've noticed that there are some changes in ``sniplates/django.html`` needed (see also https://github.com/funkybob/django-sniplates/issues/36).

This initial PR adds tests for the default widgets with the correct expected output. The following commits will fix the failing test(s). 