### PR TITLE
Change Travis config to use tox and report coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+source = sniplates
+
+[report]
+omit = */migrations/*,*/tests/*
+exclude_lines =
+    pragma: no cover
+    noqa

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,35 @@
 sudo: false
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
-  - "pypy3"
-env:
-  - DJANGO="Django<1.8"
-  - DJANGO="Django<1.9"
-  - DJANGO="Django<1.10"
-
 install:
-  - pip install $DJANGO
-
+  - pip install coverage codecov coveralls tox
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5
 script:
-  - python runtests.py
+  - tox
+after_success:
+  - coveralls
+  - codecov
+env:
+  - TOXENV=py27-django17
+  - TOXENV=py27-django18
+  - TOXENV=py27-django19
 
-matrix:
-  exclude:
-    - env: DJANGO="Django<1.8"
-      python: "3.5"
-    - env: DJANGO="Django<1.9"
-      python: "3.5"
-    - env: DJANGO="Django<1.10"
-      python: "3.3"
-    - env: DJANGO="Django<1.10"
-      python: "pypy3"
+  - TOXENV=pypy-django17
+  - TOXENV=pypy-django18
+  - TOXENV=pypy-django19
+
+  - TOXENV=py33-django17
+  - TOXENV=py33-django18
+
+  - TOXENV=py34-django17
+  - TOXENV=py34-django18
+  - TOXENV=py34-django19
+
+  - TOXENV=py35-django19
+
+  - TOXENV=pypy3-django17
+  - TOXENV=pypy3-django18

--- a/runtests.py
+++ b/runtests.py
@@ -1,32 +1,38 @@
 #!/usr/bin/env python
-
-# Adapted from https://raw.githubusercontent.com/hzy/django-polarize/master/runtests.py
-
+import os
 import sys
 
-from django.conf import settings
-from django.core.management import execute_from_command_line
 
+def runtests(args=None):
+    test_dir = os.path.dirname(__file__)
+    sys.path.insert(0, test_dir)
 
-if not settings.configured:
-    settings.configure(
-        DATABASES={
-            'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
-            }
-        },
-        INSTALLED_APPS=(
-            'sniplates',
-            'tests',
-        ),
-        MIDDLEWARE_CLASSES=[],
-    )
+    import django
+    from django.test.utils import get_runner
+    from django.conf import settings
 
+    if not settings.configured:
+        settings.configure(
+            DATABASES={
+                'default': {
+                    'ENGINE': 'django.db.backends.sqlite3',
+                }
+            },
+            INSTALLED_APPS=(
+                'sniplates',
+                'tests',
+            ),
+            MIDDLEWARE_CLASSES=[],
+        )
 
-def runtests():
-    argv = sys.argv[:1] + ['test', 'tests']
-    execute_from_command_line(argv)
+    django.setup()
+
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner(verbosity=1, interactive=True)
+    args = args or ['.']
+    failures = test_runner.run_tests(args)
+    sys.exit(failures)
 
 
 if __name__ == '__main__':
-    runtests()
+    runtests(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     include_package_data=True,
     zip_safe=False,
+    # tests
+    test_suite='runtests.runtests',
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ skip_missing_interpreters = true
 
 [testenv]
 deps=
+  coverage
   django17: Django>=1.7,<1.8
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
 commands=
-  python runtests.py
+  coverage run --rcfile={toxinidir}/.coveragerc {toxinidir}/setup.py test


### PR DESCRIPTION
* Make 'python setup.py test' working as expected
* Enabled coverage tracking in tests
* Let Travis use Tox instead of manually specifying the build matrix

Coverage results are pushed to Codecov and Coveralls. You would probably need to enable this repository there: https://codecov.io/, https://coveralls.io/. Codecov in general is a bit stricter than Coveralls (measuring branch coverage as well).