### PR TITLE
More tests for the default widgets

### DIFF
--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -96,9 +96,9 @@ How to render errors
 {% block PasswordInput %}{% reuse "input" input_type="password" value="" %}{% endblock %}
 {% block HiddenInput %}{% reuse "input" input_type="hidden" label="" %}{% endblock %}
 {% block FileInput %}{% reuse "input" input_type="file" value="" %}{% endblock %}
-{% block DateInput %}{% reuse "input" input_type="date" value=value|date:'Y-m-d' %}{% endblock %}
-{% block DateTimeInput %}{% reuse "input" input_type="datetime" value=value|date:'Y-m-d H:i:s' %}{% endblock %}
-{% block TimeInput %}{% reuse "input" input_type="time" value=value|date:'H:i:s' %}{% endblock %}
+{% block DateInput %}{% reuse "input" input_type="date" raw_value=value %}{% endblock %}
+{% block DateTimeInput %}{% reuse "input" input_type="datetime" raw_value=value %}{% endblock %}
+{% block TimeInput %}{% reuse "input" input_type="time" raw_value=value %}{% endblock %}
 
 {% block ClearableFileInput %}
 {% if file %}

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -1,8 +1,9 @@
 from collections import namedtuple
 from contextlib import contextmanager
 
-from django.forms.utils import flatatt
 from django import template
+from django.forms.utils import flatatt
+from django.forms.widgets import DateTimeBaseInput
 from django.template.base import token_kwargs
 from django.template.loader import get_template
 from django.template.loader_tags import (
@@ -391,11 +392,27 @@ class NullBooleanFieldExtractor(FieldExtractor):
         )
 
 
+class DateTimeBaseExtractor(FieldExtractor):
+    """
+    Applies the date/time/datetime formatting to the value.
+    """
+
+    @cached_property
+    def value(self):
+        if isinstance(self['widget'], DateTimeBaseInput):
+            return self['widget']._format_value(self.raw_value)
+        # if it's a different widget, fall back to the default
+        return super(DateTimeBaseExtractor, self).value
+
+
 # Map of field types to functions for extracting their data
 EXTRACTOR = {
     'FileField': FileFieldExtractor,
     'ImageField': ImageFieldExtractor,
     'NullBooleanField': NullBooleanFieldExtractor,
+    'DateField': DateTimeBaseExtractor,
+    'DateTimeField': DateTimeBaseExtractor,
+    'TimeField': DateTimeBaseExtractor,
 }
 
 

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -368,6 +368,18 @@ class NullBooleanFieldExtractor(FieldExtractor):
         return raw_value
 
     @cached_property
+    def value(self):
+        """
+        Maps True/False and 2/3 to the correct stringified version.
+
+        See ``django.forms.widgets.NullBooleanSelect.render``.
+        """
+        try:
+            return {True: '2', False: '3', '2': '2', '3': '3'}[self.raw_value]
+        except KeyError:
+            return '1'
+
+    @cached_property
     def choices(self):
         c = self['widget'].choices
         if not c:

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -32,4 +32,7 @@ class DjangoWidgetsForm(forms.Form):
         choices=((1, 'a'), (11, 'b'), (22, 'c')),
         widget=forms.CheckboxSelectMultiple
     )
+
+    file = forms.FileField(widget=forms.FileInput)
+    clearable_file = forms.FileField()
     # TODO: clearableFileInput, FileInput, Split(Hidden)DateTimeWidget

--- a/tests/templates/field_tag/widgets_django
+++ b/tests/templates/field_tag/widgets_django
@@ -3,3 +3,4 @@
 {% for field in form %}
 {% form_field field %}
 {% endfor %}
+{% form_field form.null_boolean_select %}

--- a/tests/templates/field_tag/widgets_django
+++ b/tests/templates/field_tag/widgets_django
@@ -3,4 +3,3 @@
 {% for field in form %}
 {% form_field field %}
 {% endfor %}
-{% form_field form.null_boolean_select %}

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -1,9 +1,11 @@
 """
 Tests for all shipped sniplates/django.html widgets.
 """
+import datetime
 
 from django.template.loader import get_template
 from django.test import SimpleTestCase, override_settings
+from django.utils.datastructures import MultiValueDict
 
 from .forms import DjangoWidgetsForm
 from .utils import TemplateTestMixin, template_path
@@ -12,15 +14,12 @@ from .utils import TemplateTestMixin, template_path
 @override_settings(TEMPLATE_DIRS=[template_path('field_tag')])
 class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
-    def setUp(self):
-        super(TestFieldTag, self).setUp()
-        self.ctx['form'] = DjangoWidgetsForm()
-
     def test_widgets_unbound(self):
         """
         Tests all form fields one by one, with a fresh, unbound form without
         initial data.
         """
+        self.ctx['form'] = DjangoWidgetsForm()
         tmpl = get_template('widgets_django')
         output = tmpl.render(self.ctx)
 
@@ -33,11 +32,12 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             'password': '<input type="password" name="password" id="id_password" value="" class=" " required>',
             'hidden': '<input type="hidden" name="hidden" id="id_hidden" value="" class=" " required>',
             # this one is hard to test, as it may NOT contain the output - it's empty by default
-            'multiple_hidden': '''
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_0" value="N" required>
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_1" value="o" required>
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_2" value="n" required>
-                <input type="hidden" name="multiple_hidden" id="id_multiple_hidden_3" value="e" required>''',
+            'multiple_hidden': [
+                '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_0" value="N" required>',
+                '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_1" value="o" required>',
+                '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_2" value="n" required>',
+                '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_3" value="e" required>',
+            ],
             'date': '<input type="date" name="date" id="id_date" value="" class=" " required>',
             'datetime': '<input type="datetime" name="datetime" id="id_datetime" value="" class=" " required>',
             'time': '<input type="time" name="time" id="id_time" value="" class=" " required>',
@@ -92,8 +92,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         self.assertInHTML(expected_output['password'], output, msg_prefix='PasswordInput rendered incorrectly: ')
         self.assertInHTML(expected_output['hidden'], output, msg_prefix='HiddenInput rendered incorrectly: ')
 
-        self.assertNotInHTML(
-            expected_output['multiple_hidden'], output, msg_prefix='MultipleHiddenInput rendered incorrectly: ')
+        for input_ in expected_output['multiple_hidden']:
+            self.assertNotInHTML(input_, output, msg_prefix='MultipleHiddenInput rendered incorrectly: %s: ' % input_)
         self.assertInHTML(expected_output['date'], output, msg_prefix='DateInput rendered incorrectly: ')
         self.assertInHTML(expected_output['datetime'], output, msg_prefix='DateTimeInput rendered incorrectly: ')
         self.assertInHTML(expected_output['time'], output, msg_prefix='TimeInput rendered incorrectly: ')
@@ -112,3 +112,112 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             msg_prefix='CheckboxSelectMultiple rendered incorrectly: '
         )
         self.assertInHTML(expected_output['file'], output, msg_prefix='FileInput rendered incorrectly: ')
+
+    def test_widgets_bound(self):
+        """
+        Tests all form fields one by one, with a bound form.
+        """
+        self.ctx['form'] = DjangoWidgetsForm(data=MultiValueDict({
+            'char': ['test char'],
+            'email': ['foo@bar.com'],
+            'url': ['https://example.com'],
+            'number': [42],
+            'password': ['secret'],
+            'hidden': ['peek-a-boo'],
+            'multiple_hidden': ['first', 'second'],
+            'date': [datetime.date(2016, 1, 25)],
+            'datetime': [datetime.datetime(2016, 1, 25, 9, 0, 42)],
+            'time': [datetime.time(8, 9)],
+            'text': ['Lorem ipsum...'],
+            'checkbox': [True],
+            'select': '22',
+            'null_boolean_select': [False],
+            'select_multiple': ['11', '22', 1],
+            'radio_select': ['11'],
+            'checkbox_select_multiple': ['1', 11],
+            # TODO: file/clearable_file
+        }))
+        tmpl = get_template('widgets_django')
+        output = tmpl.render(self.ctx)
+
+        expected = {
+            'char': '<input type="text" name="char" id="id_char" value="test char" class=" " required>',
+            'email': '<input type="email" name="email" id="id_email" value="foo@bar.com" class=" " required>',
+            'url': '<input type="url" name="url" id="id_url" value="https://example.com" class=" " required>',
+            'number': '<input type="number" name="number" id="id_number" value="42" class=" " required>',
+            'password': '<input type="password" name="password" id="id_password" value="secret" class=" " required>',
+            'hidden': '<input type="hidden" name="hidden" id="id_hidden" value="peek-a-boo" class=" " required>',
+            'multiple_hidden': [
+                '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_0" value="first" required>',
+                '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_1" value="second" required>',
+            ],
+            'date': '<input type="date" name="date" id="id_date" value="2016-01-25" class=" " required>',
+            'datetime': '<input type="datetime" name="datetime" id="id_datetime" value="2016-01-25 09:00:42" class=" " required>',
+            'time': '<input type="time" name="time" id="id_time" value="08:09:00" class=" " required>',
+            'text': '<textarea name="text" id="id_text" class=" " required cols="40" rows="10">Lorem ipsum...</textarea> ',
+            'checkbox': '''
+                <label for="id_checkbox" class="">
+                    <input name="checkbox" id="id_checkbox" type="checkbox" checked>
+                    Checkbox
+                </label>''',
+            'select': '''
+                <select name="select" id="id_select">
+                <option value="1">a</option>
+                <option value="11">b</option>
+                <option value="22" selected>c</option>
+                </select>''',
+            'null_boolean_select': '''
+                <select id="id_null_boolean_select" name="null_boolean_select">
+                <option value="1" selected="selected">Unknown</option>
+                <option value="2">Yes</option>
+                <option value="3" selected>No</option>
+                </select>''',
+            'select_multiple': '''
+                <select name="select_multiple" id="id_select_multiple" multiple>
+                    <option value="1" selected>a</option>
+                    <option value="11" selected>b</option>
+                    <option value="22" selected>c</option>
+                </select>''',
+            'radio_select': '''
+                <ul id="id_radio_select">
+                    <li><input name="radio_select" type="radio" id="id_radio_select_0" value="1" >a</li>
+                    <li><input name="radio_select" type="radio" id="id_radio_select_1" value="11" checked>b</li>
+                    <li><input name="radio_select" type="radio" id="id_radio_select_2" value="22" >c</li>
+                </ul>''',
+            'checkbox_select_multiple': '''
+                <ul id="id_checkbox_select_multiple">
+                    <li><input name="checkbox_select_multiple" type="checkbox"
+                        id="id_checkbox_select_multiple_0" value="1" checked>a</li>
+                    <li><input name="checkbox_select_multiple" type="checkbox"
+                        id="id_checkbox_select_multiple_1" value="11" checked>b</li>
+                    <li><input name="checkbox_select_multiple" type="checkbox"
+                        id="id_checkbox_select_multiple_2" value="22">c</li>
+                </ul>''',
+            'file': '<input id="id_file" name="file" type="file" value="" class=" " required>',
+            'clearable_file': '''
+                <input id="id_clearable_file" name="clearable_file" type="file" value="" class=" " required>''',
+        }
+
+        self.assertInHTML(expected['char'], output)
+        self.assertInHTML(expected['email'], output)
+        self.assertInHTML(expected['url'], output)
+        self.assertInHTML(expected['number'], output)
+        self.assertInHTML(expected['password'], output)
+        self.assertInHTML(expected['hidden'], output)
+        for input_ in expected['multiple_hidden']:
+            self.assertInHTML(input_, output)
+        self.assertInHTML(expected['text'], output)
+        self.assertInHTML(expected['checkbox'], output)
+
+        self.assertInHTML(expected['select_multiple'], output)
+        self.assertInHTML(expected['radio_select'], output)
+        self.assertInHTML(expected['checkbox_select_multiple'], output)
+        # self.assertInHTML(expected['file'], output)
+        # self.assertInHTML(expected['clearable_file'], output)
+
+        # failing checks: FIXME
+        self.assertInHTML(expected['date'], output)
+        self.assertInHTML(expected['datetime'], output)
+        self.assertInHTML(expected['time'], output)
+        self.assertInHTML(expected['select'], output)
+        self.assertInHTML(expected['null_boolean_select'], output)

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -217,7 +217,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         # self.assertInHTML(expected['file'], output)
         # self.assertInHTML(expected['clearable_file'], output)
 
-        # failing checks: FIXME
+        # DateTime based
         self.assertInHTML(expected['date'], output)
         self.assertInHTML(expected['datetime'], output)
         self.assertInHTML(expected['time'], output)

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -3,6 +3,7 @@ Tests for all shipped sniplates/django.html widgets.
 """
 import datetime
 
+from django import forms
 from django.template.loader import get_template
 from django.test import SimpleTestCase, override_settings
 from django.utils.datastructures import MultiValueDict
@@ -221,3 +222,18 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         self.assertInHTML(expected['date'], output)
         self.assertInHTML(expected['datetime'], output)
         self.assertInHTML(expected['time'], output)
+
+    def test_date_input_different_format(self):
+        """
+        Tests that the ``django.forms`` configured input format is respected.
+        """
+        class Form(forms.Form):
+            date = forms.DateField(widget=forms.DateInput(format='%m-%Y-%d'))
+
+        self.ctx['form'] = Form(initial={'date': datetime.date(2016, 3, 27)})
+        tmpl = get_template('widgets_django')
+        output = tmpl.render(self.ctx)
+        self.assertHTMLEqual(
+            output,
+            '<input type="date" name="date" id="id_date" value="03-2016-27" class=" " required>'
+        )

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -136,7 +136,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             'select_multiple': ['11', '22', 1],
             'radio_select': ['11'],
             'checkbox_select_multiple': ['1', 11],
-            # TODO: file/clearable_file
+            'file': ['not-a-suspicious-file.exe'],
+            'clearable_file': ['also-not-a-suspicious-file.exe'],
         }))
         tmpl = get_template('widgets_django')
         output = tmpl.render(self.ctx)
@@ -194,9 +195,10 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                     <li><input name="checkbox_select_multiple" type="checkbox"
                         id="id_checkbox_select_multiple_2" value="22">c</li>
                 </ul>''',
-            'file': '<input id="id_file" name="file" type="file" value="" class=" " required>',
+            # file inputs never show the value, the old value is of no use [see django.forms tests]
+            'file': '<input id="id_file" name="file" type="file" value="" class=" error" required>',
             'clearable_file': '''
-                <input id="id_clearable_file" name="clearable_file" type="file" value="" class=" " required>''',
+                <input id="id_clearable_file" name="clearable_file" type="file" value="" class=" error" required>''',
         }
 
         self.assertInHTML(expected['char'], output)
@@ -215,8 +217,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         self.assertInHTML(expected['select_multiple'], output)
         self.assertInHTML(expected['radio_select'], output)
         self.assertInHTML(expected['checkbox_select_multiple'], output)
-        # self.assertInHTML(expected['file'], output)
-        # self.assertInHTML(expected['clearable_file'], output)
+        self.assertInHTML(expected['file'], output)
+        self.assertInHTML(expected['clearable_file'], output)
 
         # DateTime based
         self.assertInHTML(expected['date'], output)
@@ -237,3 +239,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             output,
             '<input type="date" name="date" id="id_date" value="03-2016-27" class=" " required>'
         )
+
+    # def test_filefield_extractor(self):
+    #     """
+    #     TODO: test that the clearable file input is properly rendered.
+    #     """

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -130,7 +130,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             'time': [datetime.time(8, 9)],
             'text': ['Lorem ipsum...'],
             'checkbox': [True],
-            'select': '22',
+            'select': ['22'],
             'null_boolean_select': [False],
             'select_multiple': ['11', '22', 1],
             'radio_select': ['11'],
@@ -168,7 +168,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                 </select>''',
             'null_boolean_select': '''
                 <select id="id_null_boolean_select" name="null_boolean_select">
-                <option value="1" selected="selected">Unknown</option>
+                <option value="1">Unknown</option>
                 <option value="2">Yes</option>
                 <option value="3" selected>No</option>
                 </select>''',
@@ -209,6 +209,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         self.assertInHTML(expected['text'], output)
         self.assertInHTML(expected['checkbox'], output)
 
+        self.assertInHTML(expected['select'], output)
+        self.assertInHTML(expected['null_boolean_select'], output)
         self.assertInHTML(expected['select_multiple'], output)
         self.assertInHTML(expected['radio_select'], output)
         self.assertInHTML(expected['checkbox_select_multiple'], output)
@@ -219,5 +221,3 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         self.assertInHTML(expected['date'], output)
         self.assertInHTML(expected['datetime'], output)
         self.assertInHTML(expected['time'], output)
-        self.assertInHTML(expected['select'], output)
-        self.assertInHTML(expected['null_boolean_select'], output)

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -80,6 +80,9 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                     <li><input name="checkbox_select_multiple" type="checkbox"
                         id="id_checkbox_select_multiple_2" value="22">c</li>
                 </ul>''',
+            'file': '<input id="id_file" name="file" type="file" value="" class=" " required>',
+            'clearable_file': '''
+                <input id="id_clearable_file" name="clearable_file" type="file" value="" class=" " required>''',
         }
 
         self.assertInHTML(expected_output['char'], output, msg_prefix='TextInput rendered incorrectly: ')
@@ -108,3 +111,4 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             expected_output['checkbox_select_multiple'], output,
             msg_prefix='CheckboxSelectMultiple rendered incorrectly: '
         )
+        self.assertInHTML(expected_output['file'], output, msg_prefix='FileInput rendered incorrectly: ')


### PR DESCRIPTION
This PR adds a test that checks (most) default widgets that are shipped with sniplates, with a bound form.

Contains **fixes**
* the (nullboolean)select that was merged yesterday
* fix for datetimebased widgets (DateField, DateTimeField, TimeField)
* fix for raw values passed in to NullBooleanField

I'll have to check if I still have missed something, but this should cover the majority of cases