### PR TITLE
Bugfix with ChoiceWrapper

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -40,6 +40,8 @@ def runtests(args=None):
 
     cov.stop()
     cov.save()
+    if os.getenv('HTML_REPORT'):
+        cov.html_report()
 
     sys.exit(failures)
 

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -24,6 +24,10 @@ class DjangoWidgetsForm(forms.Form):
     text = forms.CharField(widget=forms.Textarea)
     checkbox = forms.BooleanField()
     select = forms.ChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')))
+    optgroup_select = forms.ChoiceField(choices=(
+        ('label1', [(1, 'a'), (11, 'b')]),
+        ('label2', [(22, 'c')])
+    ))
     null_boolean_select = forms.NullBooleanField()
     select_multiple = forms.MultipleChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')))
     radio_select = forms.ChoiceField(choices=((1, 'a'), (11, 'b'), (22, 'c')),

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -69,6 +69,16 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                 <option value="11">b</option>
                 <option value="22">c</option>
                 </select>''',
+            'optgroup_select': '''
+                <select id="id_optgroup_select" name="optgroup_select">
+                    <optgroup label="label1">
+                        <option value="1">a</option>
+                        <option value="11">b</option>
+                    </optgroup>
+                    <optgroup label="label2">
+                        <option value="22">c</option>
+                    </optgroup>
+                </select>''',
             'null_boolean_select': '''
                 <select id="id_null_boolean_select" name="null_boolean_select">
                 <option value="1" selected="selected">Unknown</option>
@@ -118,6 +128,8 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
         # all kind of selects
         self.assertInHTML(expected_output['select'], output, msg_prefix='Select rendered incorrectly: ')
+        self.assertInHTML(
+            expected_output['optgroup_select'], output, msg_prefix='Select with optgroups rendered incorrectly: ')
         self.assertInHTML(
             expected_output['null_boolean_select'], output, msg_prefix='NullBooleanSelect rendered incorrectly: ')
         self.assertInHTML(

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -159,6 +159,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             'text': ['Lorem ipsum...'],
             'checkbox': [True],
             'select': ['22'],
+            'optgroup_select': ['22'],
             'null_boolean_select': [False],
             'select_multiple': ['11', '22', 1],
             'radio_select': ['11'],
@@ -194,6 +195,16 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                 <option value="1">a</option>
                 <option value="11">b</option>
                 <option value="22" selected>c</option>
+                </select>''',
+            'optgroup_select': '''
+                <select id="id_optgroup_select" name="optgroup_select">
+                    <optgroup label="label1">
+                        <option value="1">a</option>
+                        <option value="11">b</option>
+                    </optgroup>
+                    <optgroup label="label2">
+                        <option value="22" selected>c</option>
+                    </optgroup>
                 </select>''',
             'null_boolean_select': '''
                 <select id="id_null_boolean_select" name="null_boolean_select">
@@ -240,6 +251,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         self.assertInHTML(expected['checkbox'], output)
 
         self.assertInHTML(expected['select'], output)
+        self.assertInHTML(expected['optgroup_select'], output)
         self.assertInHTML(expected['null_boolean_select'], output)
         self.assertInHTML(expected['select_multiple'], output)
         self.assertInHTML(expected['radio_select'], output)


### PR DESCRIPTION
ChoiceWrapper was not behaving correctly with regard to detecting the value because the nested choices value was not `force_text`ed. I added the check in the test case for bound forms.

As a side effect, it turned out that building `ChoiceWrapper` as a simple `namedtuple` was not flexible enough, so I made it a proper object that quacks like a tuple.

Version bump + pypi release would be appropriate :-)