### PR TITLE
Add Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,15 @@ after_success:
   - codecov
   - coveralls
 env:
-  - TOXENV=py27-django17
   - TOXENV=py27-django18
   - TOXENV=py27-django19
   - TOXENV=py27-django110
 
-  - TOXENV=pypy-django17
   - TOXENV=pypy-django18
   - TOXENV=pypy-django19
 
-  - TOXENV=py33-django17
   - TOXENV=py33-django18
 
-  - TOXENV=py34-django17
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django110

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,4 @@ env:
   - TOXENV=py35-django19
   - TOXENV=py35-django110
 
-  - TOXENV=pypy3-django17
   - TOXENV=pypy3-django18

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - TOXENV=py27-django17
   - TOXENV=py27-django18
   - TOXENV=py27-django19
+  - TOXENV=py27-django110
 
   - TOXENV=pypy-django17
   - TOXENV=pypy-django18
@@ -31,8 +32,10 @@ env:
   - TOXENV=py34-django17
   - TOXENV=py34-django18
   - TOXENV=py34-django19
+  - TOXENV=py34-django110
 
   - TOXENV=py35-django19
+  - TOXENV=py35-django110
 
   - TOXENV=pypy3-django17
   - TOXENV=pypy3-django18

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ an arsenal of template macros.
 Requirements
 ------------
 
-Requires Django 1.7 or newer, and is tested against Python 2.7, 3.3, 3.4, 3.5 and
+Requires Django 1.8 or newer, and is tested against Python 2.7, 3.3, 3.4, 3.5 and
 PyPy.
 
 Quick-start

--- a/runtests.py
+++ b/runtests.py
@@ -25,7 +25,16 @@ def runtests(args=None):
                 'tests',
             ),
             MIDDLEWARE_CLASSES=[],
-            TEMPLATE_DEBUG=True,  # required for coverage plugin
+            TEMPLATES=[
+                {
+                    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                    'DIRS': [],
+                    'APP_DIRS': True,
+                    'OPTIONS': {
+                        'debug': True
+                    }
+                },
+            ]
         )
 
     django.setup()

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -252,7 +252,11 @@ def nested_widget(parser, token):
     return NestedWidget(widget, nodelist, kwargs, asvar)
 
 
-class ChoiceWrapper(object):
+class ChoiceWrapper(tuple):
+
+    def __new__(cls, value=None, display=None):
+        tuple_args = [value, display]
+        return super(ChoiceWrapper, cls).__new__(cls, tuple(tuple_args))
 
     def __init__(self, value, display):
         self.value = force_text(value)
@@ -262,6 +266,7 @@ class ChoiceWrapper(object):
         return 'ChoiceWrapper(value=%s, display=%s)' % (self.value, self.display)
 
     def __iter__(self):
+        # overriden from tuple to retrun the formatted display
         yield self.value
         yield self.display
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,14 +1,12 @@
 
 from django.template import TemplateSyntaxError
 from django.template.loader import get_template
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
-from .utils import TemplateTestMixin, template_path
+from .utils import TemplateTestMixin, template_dirs
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('load_widgets')],
-)
+@template_dirs('load_widgets')
 class TestLoadWidgets(TemplateTestMixin, SimpleTestCase):
 
     def test_load_widgets(self):
@@ -30,9 +28,7 @@ class TestLoadWidgets(TemplateTestMixin, SimpleTestCase):
         self.assertEqual(output, 'success<=>winning\n')
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('invalid')],
-)
+@template_dirs('invalid')
 class TestInvalid(TemplateTestMixin, SimpleTestCase):
 
     def test_bad_name(self):
@@ -56,9 +52,7 @@ class TestInvalid(TemplateTestMixin, SimpleTestCase):
             tmpl.render(self.ctx)
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('widget_tag')],
-)
+@template_dirs('widget_tag')
 class TestWidgetTag(TemplateTestMixin, SimpleTestCase):
 
     def test_fixed(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,12 +1,10 @@
 from collections import OrderedDict
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 from django.template.loader import get_template
-from .utils import TemplateTestMixin, template_path
+from .utils import TemplateTestMixin, template_dirs
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('filters')],
-)
+@template_dirs('filters')
 class TestFilters(TemplateTestMixin, SimpleTestCase):
 
     def test_flatattrs(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,15 +1,13 @@
 
 from django.template import TemplateSyntaxError
 from django.template.loader import get_template
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
 from .forms import TestForm
-from .utils import TemplateTestMixin, template_path
+from .utils import TemplateTestMixin, template_dirs
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('field_tag')],
-)
+@template_dirs('field_tag')
 class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
     def setUp(self):

--- a/tests/test_inherited.py
+++ b/tests/test_inherited.py
@@ -1,13 +1,11 @@
 from django.template import TemplateSyntaxError
 from django.template.loader import get_template
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
-from .utils import TemplateTestMixin, template_path
+from .utils import TemplateTestMixin, template_dirs
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('inheritance')],
-)
+@template_dirs('inheritance')
 class TestInheritance(TemplateTestMixin, SimpleTestCase):
 
     def test_block_overlap(self):

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -1,15 +1,13 @@
 
 from django.template import TemplateSyntaxError
 from django.template.loader import get_template
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
 from .forms import TestForm
-from .utils import TemplateTestMixin, template_path
+from .utils import TemplateTestMixin, template_dirs
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('nested_tag')],
-)
+@template_dirs('nested_tag')
 class TestNestedTag(TemplateTestMixin, SimpleTestCase):
 
     def setUp(self):

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -1,13 +1,11 @@
 
 from django.template.loader import get_template
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
-from .utils import TemplateTestMixin, template_path
+from .utils import TemplateTestMixin, template_dirs
 
 
-@override_settings(
-    TEMPLATE_DIRS=[template_path('reuse')],
-)
+@template_dirs('reuse')
 class TestReuse(TemplateTestMixin, SimpleTestCase):
 
     def test_reuse(self):
@@ -33,4 +31,7 @@ class TestReuse(TemplateTestMixin, SimpleTestCase):
         Widget templates want to reuse their own blocks.
         '''
         tmpl = get_template('inwidget')
-        output = tmpl.render(self.ctx)
+        try:
+            tmpl.render(self.ctx)
+        except:
+            self.fail('{% reuse %} failure')

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -5,12 +5,12 @@ import datetime
 
 from django import forms
 from django.template.loader import get_template
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.datastructures import MultiValueDict
 
 from .forms import DjangoWidgetsForm, FilesForm
-from .utils import TemplateTestMixin, template_path
+from .utils import TemplateTestMixin, template_dirs
 
 
 @python_2_unicode_compatible
@@ -27,7 +27,7 @@ class FakeFieldFile(object):
         return self.url
 
 
-@override_settings(TEMPLATE_DIRS=[template_path('field_tag')])
+@template_dirs('field_tag')
 class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
     def test_widgets_unbound(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,9 @@
+import copy
 import os
 
+from django.conf import settings
 from django.template import Context
+from django.test import override_settings
 
 
 HERE = os.path.dirname(__file__)
@@ -8,6 +11,17 @@ HERE = os.path.dirname(__file__)
 
 def template_path(path):
     return os.path.join(HERE, 'templates', path, '')
+
+
+def template_dirs(*relative_dirs):
+    """
+    Convenient decorator to specify the template path.
+    """
+    # copy the original setting
+    TEMPLATES = copy.deepcopy(settings.TEMPLATES)
+    for tpl_cfg in TEMPLATES:
+        tpl_cfg['DIRS'] = [template_path(rel_dir) for rel_dir in relative_dirs]
+    return override_settings(TEMPLATES=TEMPLATES)
 
 
 class TemplateTestMixin(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py{27,py}-django{17,18,19,110},py{33,34}-django{17,18},py{34,35}-django{19,110}
+envlist = py{27,py}-django{18,19,110},py{33,34}-django{18},py{34,35}-django{19,110}
 skip_missing_interpreters = true
 
 [testenv]
 deps=
   git+https://github.com/nedbat/django_coverage_plugin.git@master
-  django17: Django>=1.7,<1.8
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
   django110: Django>=1.10,<1.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,py}-django{17,18,19},py{33,34}-django{17,18},py{34,35}-django19
+envlist = py{27,py}-django{17,18,19,110},py{33,34}-django{17,18},py{34,35}-django{19,110}
 skip_missing_interpreters = true
 
 [testenv]
@@ -8,5 +8,6 @@ deps=
   django17: Django>=1.7,<1.8
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
+  django110: Django>=1.10,<1.11
 commands=
   python {toxinidir}/setup.py test


### PR DESCRIPTION
☑ Add Django 1.10 to the build config
☑ Drop < 1.8 support
☑ Fix 1.10 issues
☑ Update docs/readme

Since Django 1.7 is not officially supported by Django core anymore, it makes sense to drop support. This also allows us to use the new `TEMPLATES` settings which makes testing a bit more enjoyable.

Currently the shipped widgets library is failing on 1.10, I'm not sure what changed, but it seems to be related to the `{% for val, display in choices %}` where the unpacking seems to be ... funky.