### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ django-sniplates
 
 Template snippet libraries for Django
 
-Read the documentation at [Read The Docs](http://sniplates.readthedocs.org/en/latest/)
+Read the documentation at [Read The Docs](https://sniplates.readthedocs.io/en/latest/)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.