### PR TITLE
WIP: {% include %} and {% load_widgets %}

### DIFF
--- a/tests/templates/include/base
+++ b/tests/templates/include/base
@@ -1,0 +1,5 @@
+{% load sniplates %}
+
+{% load_widgets widgets='widgets' %}
+
+{% include 'included' %}

--- a/tests/templates/include/included
+++ b/tests/templates/include/included
@@ -1,0 +1,5 @@
+{% load sniplates %}
+
+{% load_widgets widgets='widgets' _soft=True %}
+
+{% widget 'widgets:foo' %}

--- a/tests/templates/include/widgets
+++ b/tests/templates/include/widgets
@@ -1,0 +1,1 @@
+{% block foo %}FOO{% endblock %}

--- a/tests/test_included.py
+++ b/tests/test_included.py
@@ -1,0 +1,25 @@
+
+from django.template.loader import get_template
+from django.test import SimpleTestCase
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from .utils import TemplateTestMixin, template_dirs
+
+
+@template_dirs('include')
+class TestIncluded(TemplateTestMixin, SimpleTestCase):
+
+    def test_include_with_soft(self):
+        tmpl = get_template('base')
+        output = tmpl.render(self.ctx)
+        self.assertEqual(output.strip(), 'FOO')
+
+    @patch('sniplates.templatetags.sniplates.resolve_blocks')
+    def test_ensure_soft_only_executes_once_on_include(self, resolve_blocks):
+        tmpl = get_template('base')
+        tmpl.render(self.ctx)
+        self.assertEqual(resolve_blocks.call_count, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,6 @@ deps=
   django19: Django>=1.9,<1.10
   django110: Django>=1.10,<1.11
   django111: Django>=1.11,<1.12
+  py27: mock
 commands=
   python {toxinidir}/setup.py test


### PR DESCRIPTION
Currently, if you `{% include %}` a template into another template, then any widget sets that were loaded in the outer template are not available (even when using `_soft`) inside the inner template, without using a seperate `{% load_widgets %}`.