### PR TITLE
In the example _label widget do not set an 'id' attribute for the label element.

### DIFF
--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -56,7 +56,7 @@ Default, basic form rendering
 
 How to render labels
 {% block _label %}
-{% if label %}<label id="{{ id_for_label }}" for="{{ id }}">{{ label }}</label>{% endif %}
+{% if label %}<label for="{{ id_for_label }}">{{ label }}</label>{% endif %}
 {% endblock %}
 
 How to render help_text


### PR DESCRIPTION
Because the 'id' attribute was set for the label, the input element,
and the label use the same id. The new behavior is consistent with how
BoundField.label_tag works in Django.

Also see:
- https://docs.djangoproject.com/en/2.0/ref/forms/api/#django.forms.BoundField.id_for_label
- https://github.com/django/django/blob/master/django/forms/boundfield.py#L129
