### PR TITLE
Align with Django 'input_type' for date/time/datetime fields

### DIFF
--- a/sniplates/templates/sniplates/django.html
+++ b/sniplates/templates/sniplates/django.html
@@ -96,9 +96,9 @@ How to render errors
 {% block PasswordInput %}{% reuse "input" input_type="password" raw_value="" %}{% endblock %}
 {% block HiddenInput %}{% reuse "input" input_type="hidden" label="" %}{% endblock %}
 {% block FileInput %}{% reuse "input" input_type="file" value="" %}{% endblock %}
-{% block DateInput %}{% reuse "input" input_type="date" raw_value=value %}{% endblock %}
-{% block DateTimeInput %}{% reuse "input" input_type="datetime" raw_value=value %}{% endblock %}
-{% block TimeInput %}{% reuse "input" input_type="time" raw_value=value %}{% endblock %}
+{% block DateInput %}{% reuse "input" input_type="text" raw_value=value %}{% endblock %}
+{% block DateTimeInput %}{% reuse "input" input_type="text" raw_value=value %}{% endblock %}
+{% block TimeInput %}{% reuse "input" input_type="text" raw_value=value %}{% endblock %}
 
 {% block ClearableFileInput %}
 {% if raw_value %}

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -54,9 +54,9 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                 '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_2" value="n" required>',
                 '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_3" value="e" required>',
             ],
-            'date': '<input type="date" name="date" id="id_date" value="" class=" " required>',
-            'datetime': '<input type="datetime" name="datetime" id="id_datetime" value="" class=" " required>',
-            'time': '<input type="time" name="time" id="id_time" value="" class=" " required>',
+            'date': '<input type="text" name="date" id="id_date" value="" class=" " required>',
+            'datetime': '<input type="text" name="datetime" id="id_datetime" value="" class=" " required>',
+            'time': '<input type="text" name="time" id="id_time" value="" class=" " required>',
             'text': '<textarea name="text" id="id_text" class=" " required cols="40" rows="10"></textarea> ',
             'checkbox': '''
                 <label for="id_checkbox" class="">
@@ -182,9 +182,9 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                 '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_0" value="first" required>',
                 '<input type="hidden" name="multiple_hidden" id="id_multiple_hidden_1" value="second" required>',
             ],
-            'date': '<input type="date" name="date" id="id_date" value="2016-01-25" class=" " required>',
-            'datetime': '<input type="datetime" name="datetime" id="id_datetime" value="2016-01-25 09:00:42" class=" " required>',
-            'time': '<input type="time" name="time" id="id_time" value="08:09:00" class=" " required>',
+            'date': '<input type="text" name="date" id="id_date" value="2016-01-25" class=" " required>',
+            'datetime': '<input type="text" name="datetime" id="id_datetime" value="2016-01-25 09:00:42" class=" " required>',
+            'time': '<input type="text" name="time" id="id_time" value="08:09:00" class=" " required>',
             'text': '<textarea name="text" id="id_text" class=" " required cols="40" rows="10">Lorem ipsum...</textarea> ',
             'checkbox': '''
                 <label for="id_checkbox" class="">
@@ -277,7 +277,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         output = tmpl.render(self.ctx)
         self.assertHTMLEqual(
             output,
-            '<input type="date" name="date" id="id_date" value="03-2016-27" class=" " required>'
+            '<input type="text" name="date" id="id_date" value="03-2016-27" class=" " required>'
         )
 
     def test_filefield_extractor(self):


### PR DESCRIPTION
For DateInput, DateTimeInput and TimeInput Django uses input_type 'text'. Align sniplates with this as well.

Using 'date', 'time' or 'datetime' is problematic because the HTML standard
defines specific formatting for these input types. For example type 'date'
requires a formatting of to be YYYY-MM-DD to be set in the 'value' attribute of
the input element.

However the DateInput, DateTimeInput and TimeInput widgets use
DATE_INPUT_FORMATS, DATETIME_INPUT_FORMATS and TIME_INPUT_FORMATS respectively
to format the value.  And these settings can, and often do, differ from what is
required by browser/HTML 5.