### PR TITLE
Drop Python 2 support, add Django 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,15 @@ sudo: false
 dist: xenial  # Workaround for Ubuntu being so far behind
 language: python
 python:
-  - 3.4
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
   - pypy3.5
 
 env:
-  - DJANGO=2.0.0
-  - DJANGO=2.1.0
-
-matrix:
-  exclude:
-    - python: 3.4
-      env: DJANGO=2.1.0
+  - DJANGO=2.2.0
+  - DJANGO=3.0.0
 
 script: ./runtests.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ env:
   - DJANGO=2.2.0
   - DJANGO=3.0.0
 
+matrix:
+  exclude:
+    - python: 3.5
+      env: DJANGO=3.0.0
+    - python: pypy3.5
+      env: DJANGO=3.0.0
+
 script: ./runtests.py
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -16,19 +16,20 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: Implementation :: PyPy',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     requires=[
-        'Django (>=1.11)',
+        'Django (>=2.2)',
     ],
     install_requires=[
-        'Django>=1.11',
+        'Django>=2.2',
     ],
 )

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -7,7 +7,6 @@ from django.forms.widgets import DateTimeBaseInput
 from django.template.base import token_kwargs
 from django.template.loader import get_template
 from django.template.loader_tags import BLOCK_CONTEXT_KEY, BlockContext, BlockNode, ExtendsNode
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 
@@ -40,7 +39,7 @@ def resolve_blocks(template, context):
         blocks = context.render_context[BLOCK_CONTEXT_KEY] = BlockContext()
 
     # If it's just the name, resolve into template
-    if isinstance(template, six.string_types):
+    if isinstance(template, str):
         template = get_template(template)
 
     # For Django 1.8 compatibility

--- a/sniplates/templatetags/sniplates.py
+++ b/sniplates/templatetags/sniplates.py
@@ -383,12 +383,12 @@ class NullBooleanFieldExtractor(FieldExtractor):
     @cached_property
     def raw_value(self):
         """
-        When the value is None, it's actually rendered as '1', see
-        ``django.forms.widgets.NullBooleanSelect.render``
+        When the value is None, it's actually rendered as 'unknown', see
+        ``django.forms.widgets.NullBooleanSelect.__init__``
         """
-        raw_value = super(NullBooleanFieldExtractor, self).raw_value
+        raw_value = super().raw_value
         if raw_value is None:
-            return '1'
+            return 'unknown'
         return raw_value
 
     @cached_property
@@ -396,12 +396,21 @@ class NullBooleanFieldExtractor(FieldExtractor):
         """
         Maps True/False and 2/3 to the correct stringified version.
 
-        See ``django.forms.widgets.NullBooleanSelect.render``.
+        See ``django.forms.widgets.NullBooleanSelect.value_from_datadict``.
         """
         try:
-            return {True: '2', False: '3', '2': '2', '3': '3'}[self.raw_value]
+            return {
+                True: 'true',
+                False: 'false',
+                'true': 'true',
+                'false': 'false',
+                'True': 'true',
+                'False': 'false',
+                '2': 'true',
+                '3': 'false'
+            }[self.raw_value]
         except KeyError:
-            return '1'
+            return 'unknown'
 
     @cached_property
     def choices(self):

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -6,14 +6,12 @@ import datetime
 from django import forms
 from django.template.loader import get_template
 from django.test import SimpleTestCase
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.datastructures import MultiValueDict
 
 from .forms import DjangoWidgetsForm, FilesForm
 from .utils import TemplateTestMixin, template_dirs
 
 
-@python_2_unicode_compatible
 class FakeFieldFile(object):
     """
     Quacks like a FieldFile (has a .url and unicode representation), but

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -81,9 +81,9 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                 </select>''',
             'null_boolean_select': '''
                 <select id="id_null_boolean_select" name="null_boolean_select">
-                <option value="1" selected="selected">Unknown</option>
-                <option value="2">Yes</option>
-                <option value="3">No</option>
+                <option value="unknown" selected>Unknown</option>
+                <option value="true">Yes</option>
+                <option value="false">No</option>
                 </select>''',
             'select_multiple': '''
                 <select name="select_multiple" id="id_select_multiple" multiple>
@@ -160,7 +160,7 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
             'checkbox': [True],
             'select': ['22'],
             'optgroup_select': ['22'],
-            'null_boolean_select': [False],
+            'null_boolean_select': ["false"],
             'select_multiple': ['11', '22', 1],
             'radio_select': ['11'],
             'checkbox_select_multiple': ['1', 11],
@@ -209,9 +209,9 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
                 </select>''',
             'null_boolean_select': '''
                 <select id="id_null_boolean_select" name="null_boolean_select">
-                <option value="1">Unknown</option>
-                <option value="2">Yes</option>
-                <option value="3" selected>No</option>
+                    <option value="unknown">Unknown</option>
+                    <option value="true">Yes</option>
+                    <option value="false" selected>No</option>
                 </select>''',
             'select_multiple': '''
                 <select name="select_multiple" id="id_select_multiple" multiple>


### PR DESCRIPTION
* Added Python 3.8 to test matrix
* Updated PyPI classifiers

Django 3.0 currently crashes on the import of `django.utils.six`, and Python 2 is EOL.