### PR TITLE
Support Django 4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sniplates"
-version = "0.7.1"
+version = "0.7.2"
 description = "Efficient template macro sets for Django"
 authors = ["Curtis Maloney <curtis@tinbrain.net>"]
 readme = "README.md"
@@ -15,14 +15,15 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-django = "^3.0.5"
+python = ">=3.8"
+django = ">=3.0.5"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7.9"

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -2,7 +2,7 @@
 Tests for all shipped sniplates/django.html widgets.
 """
 import datetime
-
+import django
 from django import forms
 from django.template.loader import get_template
 from django.test import SimpleTestCase
@@ -40,7 +40,10 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         # map field to expected widget output
         expected_output = {
             'char': '<input type="text" name="char" id="id_char" value="" class=" " required>',
-            'email': '<input type="email" name="email" id="id_email" value="" class=" " required>',
+            'email': {
+                '<3.2.20': '<input type="email" name="email" id="id_email" value="" class=" " required>',
+                '>=3.2.20': '<input type="email" name="email" id="id_email" value="" class=" " maxlength="320" required>',
+            },
             'url': '<input type="url" name="url" id="id_url" value="" class=" " required>',
             'number': '<input type="number" name="number" id="id_number" value="" class=" " required>',
             'password': '<input type="password" name="password" id="id_password" value="" class=" " required>',
@@ -110,7 +113,10 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         }
 
         self.assertInHTML(expected_output['char'], output, msg_prefix='TextInput rendered incorrectly: ')
-        self.assertInHTML(expected_output['email'], output, msg_prefix='EmailInput rendered incorrectly: ')
+        if django.VERSION < (3, 2, 20):
+            self.assertInHTML(expected_output['email']['<3.2.20'], output, msg_prefix='EmailInput rendered incorrectly: ')
+        else:
+            self.assertInHTML(expected_output['email']['>=3.2.20'], output, msg_prefix='EmailInput rendered incorrectly: ')
         self.assertInHTML(expected_output['url'], output, msg_prefix='UrlInput rendered incorrectly: ')
         self.assertInHTML(expected_output['number'], output, msg_prefix='NumberInput rendered incorrectly: ')
         self.assertInHTML(expected_output['password'], output, msg_prefix='PasswordInput rendered incorrectly: ')
@@ -170,7 +176,10 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
 
         expected = {
             'char': '<input type="text" name="char" id="id_char" value="test char" class=" " required>',
-            'email': '<input type="email" name="email" id="id_email" value="foo@bar.com" class=" " required>',
+            'email': {
+                '<3.2.20': '<input type="email" name="email" id="id_email" value="foo@bar.com" class=" " required>',
+                '>=3.2.20': '<input type="email" name="email" id="id_email" value="foo@bar.com" class=" " maxlength="320" required>',
+            },
             'url': '<input type="url" name="url" id="id_url" value="https://example.com" class=" " required>',
             'number': '<input type="number" name="number" id="id_number" value="42" class=" " required>',
             # Password inputs should not re-render their contents.
@@ -239,7 +248,10 @@ class TestFieldTag(TemplateTestMixin, SimpleTestCase):
         }
 
         self.assertInHTML(expected['char'], output)
-        self.assertInHTML(expected['email'], output)
+        if django.VERSION < (3, 2, 20):
+            self.assertInHTML(expected['email']['<3.2.20'], output)
+        else:
+            self.assertInHTML(expected['email']['>=3.2.20'], output)
         self.assertInHTML(expected['url'], output)
         self.assertInHTML(expected['number'], output)
         self.assertInHTML(expected['password'], output)


### PR DESCRIPTION
Bump version
Increase the minimum Python version to allow Django 4.2 to install
Fix test for change made in Django 3.2.20 (works with earlier versions as well) - https://docs.djangoproject.com/en/4.2/releases/3.2.20/