### PR TITLE
Widget tag refresh

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,3 +22,4 @@ TEMPLATES=[
     },
 ]
 
+USE_TZ = True

--- a/tests/test_widgets_django.py
+++ b/tests/test_widgets_django.py
@@ -13,7 +13,7 @@ from .forms import DjangoWidgetsForm, FilesForm
 from .utils import TemplateTestMixin, template_dirs
 
 
-class FakeFieldFile(object):
+class FakeFieldFile:
     """
     Quacks like a FieldFile (has a .url and unicode representation), but
     doesn't require us to care about storages etc.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,9 +22,10 @@ def template_dirs(*relative_dirs):
     return override_settings(TEMPLATES=TEMPLATES)
 
 
-class TemplateTestMixin(object):
+class TemplateTestMixin:
 
     def setUp(self):
+        super().setUp()
         self.ctx = {}
 
     def assertNotInHTML(self, needle, haystack, msg_prefix=''):


### PR DESCRIPTION
Have rewritten the `{% widget %}` tag, as `simple_tag` now supports `as` syntax.

Also reworked `auto_widget` to use f-strings